### PR TITLE
Add staging Azure AD B2C templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,22 @@
 開発環境のテンプレートです。
 
 > **Spec** → see [/spec/dev-environment.md](spec/dev-environment.md)
+
+## Azure AD B2C 設定
+
+本番およびローカル Docker 開発で使用する Azure AD B2C の設定テンプレートを `env/` 配下に用意しています。
+
+```text
+env/
+  dev/
+    .env              # Docker 用環境変数サンプル
+    appsettings.json  # Functions などで利用する構成値
+  stg/
+    .env              # Staging 用
+    appsettings.json
+  prod/
+    .env
+    appsettings.json
+```
+
+必要に応じてクライアント ID やシークレットを上書きしてください。Secrets 管理は Key Vault を利用する想定です。

--- a/env/dev/.env
+++ b/env/dev/.env
@@ -1,0 +1,5 @@
+B2C_TENANT=contoso.onmicrosoft.com
+B2C_CLIENT_ID=00000000-0000-0000-0000-000000000000
+B2C_DOMAIN=contoso.b2clogin.com
+B2C_POLICY=B2C_1_signupsignin
+B2C_CLIENT_SECRET=development-secret

--- a/env/dev/appsettings.json
+++ b/env/dev/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "AzureAdB2C": {
+    "Tenant": "contoso.onmicrosoft.com",
+    "ClientId": "00000000-0000-0000-0000-000000000000",
+    "Domain": "contoso.b2clogin.com",
+    "SignUpSignInPolicyId": "B2C_1_signupsignin",
+    "ClientSecret": "development-secret"
+  }
+}

--- a/env/prod/.env
+++ b/env/prod/.env
@@ -1,0 +1,5 @@
+B2C_TENANT=contoso.onmicrosoft.com
+B2C_CLIENT_ID=11111111-1111-1111-1111-111111111111
+B2C_DOMAIN=contoso.b2clogin.com
+B2C_POLICY=B2C_1_signupsignin
+B2C_CLIENT_SECRET=<set-via-keyvault>

--- a/env/prod/appsettings.json
+++ b/env/prod/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "AzureAdB2C": {
+    "Tenant": "contoso.onmicrosoft.com",
+    "ClientId": "11111111-1111-1111-1111-111111111111",
+    "Domain": "contoso.b2clogin.com",
+    "SignUpSignInPolicyId": "B2C_1_signupsignin",
+    "ClientSecret": "<set-via-keyvault>"
+  }
+}

--- a/env/stg/.env
+++ b/env/stg/.env
@@ -1,0 +1,5 @@
+B2C_TENANT=contoso.onmicrosoft.com
+B2C_CLIENT_ID=22222222-2222-2222-2222-222222222222
+B2C_DOMAIN=contoso.b2clogin.com
+B2C_POLICY=B2C_1_signupsignin
+B2C_CLIENT_SECRET=staging-secret

--- a/env/stg/appsettings.json
+++ b/env/stg/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "AzureAdB2C": {
+    "Tenant": "contoso.onmicrosoft.com",
+    "ClientId": "22222222-2222-2222-2222-222222222222",
+    "Domain": "contoso.b2clogin.com",
+    "SignUpSignInPolicyId": "B2C_1_signupsignin",
+    "ClientSecret": "staging-secret"
+  }
+}


### PR DESCRIPTION
## Summary
- document staging environment in README
- add staging config samples for Azure AD B2C

## Testing
- `dotnet --list-sdks`
- `dotnet restore` *(fails: no solution file)*

------
https://chatgpt.com/codex/tasks/task_e_684c30ff01a88320ba2406a5288b3870