### PR TITLE
Implement Azure AD B2C auth template

### DIFF
--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -9,5 +9,6 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.18.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.12" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="3.9.3" />
   </ItemGroup>
 </Project>

--- a/src/Api/AzureAdB2COptions.cs
+++ b/src/Api/AzureAdB2COptions.cs
@@ -1,0 +1,10 @@
+namespace Api;
+
+public class AzureAdB2COptions
+{
+    public string Tenant { get; set; } = string.Empty;
+    public string ClientId { get; set; } = string.Empty;
+    public string Domain { get; set; } = string.Empty;
+    public string SignUpSignInPolicyId { get; set; } = string.Empty;
+    public string ClientSecret { get; set; } = string.Empty;
+}

--- a/src/Api/MeFunction.cs
+++ b/src/Api/MeFunction.cs
@@ -1,0 +1,22 @@
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using System.Net;
+using System.Security.Claims;
+
+public class MeFunction
+{
+    [Function("Me")]
+    public HttpResponseData Run([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "me")] HttpRequestData req, FunctionContext context)
+    {
+        if (context.Items.TryGetValue("User", out var principalObj) && principalObj is ClaimsPrincipal user)
+        {
+            var res = req.CreateResponse(HttpStatusCode.OK);
+            res.Headers.Add("Content-Type", "application/json");
+            res.WriteString($"{{ \"name\": \"{user.Identity?.Name}\" }}");
+            return res;
+        }
+
+        var unauthorized = req.CreateResponse(HttpStatusCode.Unauthorized);
+        return unauthorized;
+    }
+}

--- a/src/Api/Middleware/JwtValidationMiddleware.cs
+++ b/src/Api/Middleware/JwtValidationMiddleware.cs
@@ -1,0 +1,79 @@
+using System.IdentityModel.Tokens.Jwt;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Middleware;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Threading;
+using System;
+using System.Net;
+using Microsoft.Azure.Functions.Worker.Http;
+using Api;
+
+public sealed class JwtValidationMiddleware : IFunctionsWorkerMiddleware
+{
+    private readonly JwtSecurityTokenHandler _handler = new();
+    private readonly ConfigurationManager<OpenIdConnectConfiguration> _configManager;
+    private readonly AzureAdB2COptions _options;
+
+    public JwtValidationMiddleware(IOptions<AzureAdB2COptions> options)
+    {
+        _options = options.Value;
+        var metadataAddress = $"https://{_options.Domain}/{_options.Tenant}/v2.0/.well-known/openid-configuration?p={_options.SignUpSignInPolicyId}";
+        _configManager = new ConfigurationManager<OpenIdConnectConfiguration>(metadataAddress, new OpenIdConnectConfigurationRetriever());
+    }
+
+    public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
+    {
+        var req = await context.GetHttpRequestDataAsync();
+        if (req is null)
+        {
+            await next(context);
+            return;
+        }
+
+        if (!req.Headers.TryGetValues("Authorization", out var authHeaders))
+        {
+            var res = req.CreateResponse(System.Net.HttpStatusCode.Unauthorized);
+            res.WriteString("Missing Authorization header");
+            context.GetInvocationResult().Value = res;
+            return;
+        }
+
+        var token = authHeaders.FirstOrDefault()?.Split(' ').LastOrDefault();
+        if (string.IsNullOrEmpty(token))
+        {
+            var res = req.CreateResponse(System.Net.HttpStatusCode.Unauthorized);
+            res.WriteString("Invalid token");
+            context.GetInvocationResult().Value = res;
+            return;
+        }
+
+        var config = await _configManager.GetConfigurationAsync(CancellationToken.None);
+        var validationParameters = new TokenValidationParameters
+        {
+            ValidAudience = _options.ClientId,
+            ValidIssuer = $"https://{_options.Domain}/{_options.Tenant}/v2.0/",
+            IssuerSigningKeys = config.SigningKeys,
+            ValidateLifetime = true,
+            ValidateAudience = true,
+            ValidateIssuer = true
+        };
+
+        try
+        {
+            var principal = _handler.ValidateToken(token, validationParameters, out _);
+            context.Items["User"] = principal;
+            await next(context);
+        }
+        catch (Exception)
+        {
+            var res = req.CreateResponse(System.Net.HttpStatusCode.Unauthorized);
+            res.WriteString("Unauthorized");
+            context.GetInvocationResult().Value = res;
+        }
+    }
+}

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -1,7 +1,27 @@
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Identity.Web;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Api;
 
 var host = new HostBuilder()
-    .ConfigureFunctionsWorkerDefaults()
+    .ConfigureAppConfiguration((context, config) =>
+    {
+        config.AddJsonFile("appsettings.json", optional: true)
+              .AddJsonFile($"appsettings.{context.HostingEnvironment.EnvironmentName}.json", optional: true)
+              .AddEnvironmentVariables();
+    })
+    .ConfigureServices((context, services) =>
+    {
+        services.Configure<AzureAdB2COptions>(context.Configuration.GetSection("AzureAdB2C"));
+        services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+                .AddMicrosoftIdentityWebApi(context.Configuration.GetSection("AzureAdB2C"));
+    })
+    .ConfigureFunctionsWorkerDefaults(worker =>
+    {
+        worker.UseMiddleware<JwtValidationMiddleware>();
+    })
     .Build();
 
 host.Run();


### PR DESCRIPTION
## Summary
- add Azure AD B2C options model and JWT middleware
- configure Functions app to use Microsoft.Identity.Web
- add authenticated `/me` endpoint

## Testing
- `dotnet build ServiceStarterKit.sln -c Release`
- `dotnet test ServiceStarterKit.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_684c93642ccc8320b26211f95da04fd6