### PR TITLE
Add devcontainer and shared utilities

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,5 +9,5 @@
     "ghcr.io/devcontainers/features/bicep:1": {}
   },
   "forwardPorts": [7071],
-  "postCreateCommand": "dotnet --version"
+  "postCreateCommand": "dotnet --version && docker-compose up -d sqlserver azurite otelcollector"
 }

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ SQL Server と Azurite をまとめて起動できます。
 docker-compose up -d
 ```
 
+## Dev Container を利用する
+
+VS Code の Remote Containers 拡張からこのリポジトリを開くと、`.devcontainer` の設定に基づいた開発環境が自動で構築されます。初回セットアップ時に `docker-compose` で SQL Server や Azurite などの依存サービスが起動します。
+
 
 ## テスト実行
 

--- a/env/dev/appsettings.json
+++ b/env/dev/appsettings.json
@@ -8,6 +8,7 @@
   },
   "Storage": {
     "ConnectionString": "UseDevelopmentStorage=true"
+  },
   "ConnectionStrings": {
     "Default": "Server=sqlserver,1433;Database=appdb;User Id=sa;Password=Your_password123;Encrypt=False"
   }

--- a/env/prod/appsettings.json
+++ b/env/prod/appsettings.json
@@ -8,6 +8,7 @@
   },
   "Storage": {
     "ConnectionString": "<set-in-keyvault>"
+  },
   "ConnectionStrings": {
     "Default": "<set-via-keyvault>"
   }

--- a/env/stg/appsettings.json
+++ b/env/stg/appsettings.json
@@ -8,6 +8,7 @@
   },
   "Storage": {
     "ConnectionString": "<set-in-keyvault>"
+  },
   "ConnectionStrings": {
     "Default": "<set-via-keyvault>"
   }

--- a/src/Shared/IDateTimeProvider.cs
+++ b/src/Shared/IDateTimeProvider.cs
@@ -1,0 +1,6 @@
+namespace Shared;
+
+public interface IDateTimeProvider
+{
+    DateTime UtcNow { get; }
+}

--- a/src/Shared/RetryHelper.cs
+++ b/src/Shared/RetryHelper.cs
@@ -1,0 +1,20 @@
+namespace Shared;
+
+public static class RetryHelper
+{
+    public static async Task<T> RetryAsync<T>(Func<int, Task<T>> action, int maxAttempts = 3, TimeSpan? delay = null)
+    {
+        delay ??= TimeSpan.FromMilliseconds(200);
+        for (int attempt = 1; ; attempt++)
+        {
+            try
+            {
+                return await action(attempt);
+            }
+            catch when (attempt < maxAttempts)
+            {
+                await Task.Delay(delay.Value);
+            }
+        }
+    }
+}

--- a/src/Shared/SystemDateTimeProvider.cs
+++ b/src/Shared/SystemDateTimeProvider.cs
@@ -1,0 +1,6 @@
+namespace Shared;
+
+public sealed class SystemDateTimeProvider : IDateTimeProvider
+{
+    public DateTime UtcNow => DateTime.UtcNow;
+}

--- a/tests/Shared.Tests/DateTimeProviderTests.cs
+++ b/tests/Shared.Tests/DateTimeProviderTests.cs
@@ -1,0 +1,15 @@
+using Shared;
+
+namespace Shared.Tests;
+
+public class DateTimeProviderTests
+{
+    [Fact]
+    public void UtcNowCloseToSystemTime()
+    {
+        IDateTimeProvider provider = new SystemDateTimeProvider();
+        var now = DateTime.UtcNow;
+        var diff = (provider.UtcNow - now).TotalSeconds;
+        Assert.True(Math.Abs(diff) < 1);
+    }
+}

--- a/tests/Shared.Tests/RetryHelperTests.cs
+++ b/tests/Shared.Tests/RetryHelperTests.cs
@@ -1,0 +1,23 @@
+using Shared;
+
+namespace Shared.Tests;
+
+public class RetryHelperTests
+{
+    [Fact]
+    public async Task RetryAsyncRetriesUntilSuccess()
+    {
+        int attempts = 0;
+        int result = await RetryHelper.RetryAsync<int>(async attempt =>
+        {
+            attempts++;
+            if (attempts < 3)
+                throw new InvalidOperationException();
+            await Task.Delay(10);
+            return 42;
+        }, maxAttempts: 5);
+
+        Assert.Equal(3, attempts);
+        Assert.Equal(42, result);
+    }
+}


### PR DESCRIPTION
## Summary
- improve devcontainer to auto-start docker-compose services
- fix sample appsettings JSON
- implement `IDateTimeProvider` and `SystemDateTimeProvider`
- add generic `RetryHelper`
- document how to use the Dev Container
- test new shared helpers

## Testing
- `dotnet test ServiceStarterKit.sln`

------
https://chatgpt.com/codex/tasks/task_e_684ca23e45a88320a60c9f2039732c68